### PR TITLE
feat: add rule to enforce comment style

### DIFF
--- a/src/rules/comment.ts
+++ b/src/rules/comment.ts
@@ -1,0 +1,76 @@
+import { createRule } from '../util';
+
+export const ruleName = 'comment-syntax';
+
+type Options = [];
+
+type MessageIds = 'lineCommentCapital' | 'lineCommentEnding' | 'blockCommentCapital' | 'blockCommentEnding';
+
+export default createRule<Options, MessageIds>({
+  name: ruleName,
+  meta: {
+    type: 'layout',
+    docs: {
+      category: 'Best Practices',
+      description: `Enforce block comments to have capital first letter and end with dots and 
+      line comments no capital first letter and no dot`,
+      recommended: 'error',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      lineCommentCapital: 'A line comment cannot start with a capital letter',
+      lineCommentEnding: 'A line comment cannot end with a dot',
+      blockCommentCapital: 'A block comment has to start with a capital letter',
+      blockCommentEnding: 'A block comment has to end with a dot',
+    },
+  },
+  defaultOptions: [],
+  create: (context) => {
+    const source = context.getSourceCode();
+
+    const comments = source.getAllComments();
+
+    const isCapital = (char: string) => {
+      return char !== char.toLowerCase();
+    };
+
+    return {
+      Program() {
+        for (const comment of comments) {
+          if (comment.type === 'Line') {
+            // prettier will add a space after the '//' by default so we need the second index
+            const firstChar = comment.value[1];
+            const lastChar = comment.value[comment.value.length - 1];
+
+            if (isCapital(firstChar)) {
+              context.report({ node: comment, messageId: 'lineCommentCapital' });
+            }
+
+            if (lastChar === '.') {
+              context.report({ node: comment, messageId: 'lineCommentEnding' });
+            }
+
+            continue;
+          }
+
+          if (comment.type === 'Block') {
+            // prettier will add format it so the firstChar is at index 5
+            const firstChar = comment.value[5];
+            const lastChar = comment.value[comment.value.length - 3];
+
+            if (!isCapital(firstChar)) {
+              context.report({ node: comment, messageId: 'blockCommentCapital' });
+            }
+
+            if (lastChar !== '.') {
+              context.report({ node: comment, messageId: 'blockCommentEnding' });
+            }
+
+            continue;
+          }
+        }
+      },
+    };
+  },
+});

--- a/src/rules/comment.ts
+++ b/src/rules/comment.ts
@@ -17,7 +17,7 @@ type MessageIds =
   | 'shouldStartWithBlock';
 
 const isCapital = (char: string) => {
-  return char !== char.toLowerCase();
+  return char === char.toUpperCase();
 };
 
 const isWholeFirstWordCapital = (sentence: string) => {

--- a/src/rules/comment.ts
+++ b/src/rules/comment.ts
@@ -16,6 +16,28 @@ type MessageIds =
   | 'shouldStartWithSpace'
   | 'shouldStartWithBlock';
 
+const isCapital = (char: string) => {
+  return char !== char.toLowerCase();
+};
+
+const isWholeFirstWordCapital = (sentence: string) => {
+  for (let char of sentence) {
+    if (char.charCodeAt(0) === SPACE_CHARCODE) {
+      return true;
+    }
+
+    if (!isCapital(char)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const isLetter = (char: string) => {
+  return char.toLowerCase() !== char.toUpperCase();
+};
+
 export default createRule<Options, MessageIds>({
   name: ruleName,
   meta: {
@@ -31,7 +53,7 @@ export default createRule<Options, MessageIds>({
     messages: {
       shouldStartWithSpace: 'A line comment should start with a space',
       shouldStartWithBlock: 'A block comment should start with /**\n *',
-      lineCommentCapital: 'A line comment cannot start with a capital letter unless the entire word is',
+      lineCommentCapital: 'A line comment cannot start with a capital letter unless the entire word is capitalised',
       lineCommentEnding: 'A line comment cannot end with a dot',
       blockCommentCapital: 'A block comment has to start with a capital letter',
       blockCommentEnding: 'A block comment has to end with a dot',
@@ -39,34 +61,12 @@ export default createRule<Options, MessageIds>({
   },
   defaultOptions: [],
   create: (context) => {
-    const source = context.getSourceCode();
-
-    const comments = source.getAllComments();
-
-    const isCapital = (char: string) => {
-      return char !== char.toLowerCase();
-    };
-
-    const isWholeFirstWordCapital = (sentence: string) => {
-      for (let char of sentence) {
-        if (char.charCodeAt(0) === SPACE_CHARCODE) {
-          return true;
-        }
-
-        if (!isCapital(char)) {
-          return false;
-        }
-      }
-
-      return true;
-    };
-
-    const isLetter = (c: string) => {
-      return c.toLowerCase() != c.toUpperCase();
-    };
-
     return {
       Program() {
+        const source = context.getSourceCode();
+
+        const comments = source.getAllComments();
+
         for (const comment of comments) {
           if (comment.type === 'Line') {
             const secondChar = comment.value[1];

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -2,10 +2,12 @@ import blockScopeCase, { ruleName as blockScopeCaseRuleName } from './block-scop
 import catchErrorName, { ruleName as catchErrorNameRuleName } from './catch-error-name';
 import linesAroundComment, { ruleName as linesAroundCommentRuleName } from './lines-around-comment';
 import newlineBeforeReturn, { ruleName as newlineBeforeReturnRuleName } from './newline-before-return';
+import commentRule, { ruleName as commentRuleName } from './comment';
 
 export = {
   [blockScopeCaseRuleName]: blockScopeCase,
   [newlineBeforeReturnRuleName]: newlineBeforeReturn,
   [linesAroundCommentRuleName]: linesAroundComment,
   [catchErrorNameRuleName]: catchErrorName,
+  [commentRuleName]: commentRule,
 };

--- a/test/rules/comment.spec.ts
+++ b/test/rules/comment.spec.ts
@@ -12,17 +12,51 @@ ruleTester().run(ruleName, rule, {
     ),
     fromFixture(
       stripIndent`
+          // SHOULD be valid
+        `
+    ),
+    fromFixture(
+      stripIndent`
+          // \` should be valid
+        `
+    ),
+    fromFixture(
+      stripIndent`
         /**
          * This should start with a capital and end with a dot.
          */
       `
     ),
+    fromFixture(
+      stripIndent`
+          /**
+           * THIS should start with a capital and end with a dot.
+           */
+        `
+    ),
+    fromFixture(
+      stripIndent`
+            /**
+             * \` should be valid.
+             */
+        `
+    ),
   ],
   invalid: [
     {
       code: stripIndent`
-        // Should throw
-      `,
+            //should throw
+          `,
+      errors: [
+        {
+          messageId: 'shouldStartWithSpace',
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+              // THiS throw
+            `,
       errors: [
         {
           messageId: 'lineCommentCapital',
@@ -31,8 +65,18 @@ ruleTester().run(ruleName, rule, {
     },
     {
       code: stripIndent`
-          // should throw for the .
+          // Should throw
         `,
+      errors: [
+        {
+          messageId: 'lineCommentCapital',
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+            // should throw for the .
+          `,
       errors: [
         {
           messageId: 'lineCommentEnding',
@@ -41,10 +85,10 @@ ruleTester().run(ruleName, rule, {
     },
     {
       code: stripIndent`
-          /**
-           * should throw for the lack of capital.
-           */
-        `,
+            /**
+             * should throw for the lack of capital.
+             */
+          `,
       errors: [
         {
           messageId: 'blockCommentCapital',
@@ -53,13 +97,36 @@ ruleTester().run(ruleName, rule, {
     },
     {
       code: stripIndent`
-            /**
-             * Should throw for the lack of capital
-             */
-        `,
+              /**
+               * Should throw for the lack of capital
+               */
+          `,
       errors: [
         {
           messageId: 'blockCommentEnding',
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+                /**               * Should throw for lack of newline.
+                 */
+            `,
+      errors: [
+        {
+          messageId: 'shouldStartWithBlock',
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+                /**
+                 *Should throw for the lack of a space.
+                 */
+            `,
+      errors: [
+        {
+          messageId: 'shouldStartWithBlock',
         },
       ],
     },

--- a/test/rules/comment.spec.ts
+++ b/test/rules/comment.spec.ts
@@ -1,0 +1,67 @@
+import { stripIndent } from 'common-tags';
+import { fromFixture } from 'eslint-etc';
+import rule, { ruleName } from '../../src/rules/comment';
+import { ruleTester } from '../utils';
+
+ruleTester().run(ruleName, rule, {
+  valid: [
+    fromFixture(
+      stripIndent`
+        // no capital or dots allowed here
+      `
+    ),
+    fromFixture(
+      stripIndent`
+        /**
+         * This should start with a capital and end with a dot.
+         */
+      `
+    ),
+  ],
+  invalid: [
+    {
+      code: stripIndent`
+        // Should throw
+      `,
+      errors: [
+        {
+          messageId: 'lineCommentCapital',
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+          // should throw for the .
+        `,
+      errors: [
+        {
+          messageId: 'lineCommentEnding',
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+          /**
+           * should throw for the lack of capital.
+           */
+        `,
+      errors: [
+        {
+          messageId: 'blockCommentCapital',
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+            /**
+             * Should throw for the lack of capital
+             */
+        `,
+      errors: [
+        {
+          messageId: 'blockCommentEnding',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Added a lint rule to verify the line comments do not start with a capital letter or end with a dot and have to start with a capital and end with a dot.

I had to make some assumptions on the structure of the comment (based on how prettier formats them) cause I didn't want to use a regex to extract the first arg. That could make the rule much slower I think. Feel free to propose a better way to extract the args.