### PR TITLE
feat: support more extended use cases for the comment syntax

### DIFF
--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -159,11 +159,9 @@ export = {
         allowMemberCallExpression: true,
       },
     ],
-
     '@blitz/block-scope-case': 'error',
-
     '@blitz/newline-before-return': 'error',
-
     '@blitz/catch-error-name': 'error',
+    '@blitz/comment-syntax': 'error',
   },
 };

--- a/src/rules/comment.ts
+++ b/src/rules/comment.ts
@@ -2,7 +2,11 @@ import { createRule } from '../util';
 
 export const ruleName = 'comment-syntax';
 
-type Options = [];
+type Options = [
+  {
+    lineCommentAllowedCapitalisedWords: string[];
+  }
+];
 
 const SPACE_CHARCODE = 32;
 const NEWLINE_CHARCODE = 10;
@@ -20,22 +24,50 @@ const isCapital = (char: string) => {
   return char === char.toUpperCase();
 };
 
-const isWholeFirstWordCapital = (sentence: string) => {
-  for (let char of sentence) {
-    if (char.charCodeAt(0) === SPACE_CHARCODE) {
-      return true;
+const isWholeFirstWordCapitalOrAllowed = (sentence: string, allowedWords: string[]) => {
+  let firstWord = '';
+  let isWordCapital = true;
+
+  for (const char of sentence) {
+    if (char?.charCodeAt(0) === SPACE_CHARCODE || !isLetter(char)) {
+      break;
+    }
+
+    if (isLetter(char)) {
+      firstWord += char;
     }
 
     if (!isCapital(char)) {
-      return false;
+      isWordCapital = false;
     }
   }
 
-  return true;
+  if (isWordCapital) {
+    return true;
+  }
+
+  if (allowedWords.includes(firstWord)) {
+    return true;
+  }
+
+  return false;
 };
 
 const isLetter = (char: string) => {
-  return char.toLowerCase() !== char.toUpperCase();
+  return char && char.toLowerCase() !== char.toUpperCase();
+};
+
+const isJsDoc = (comment: string) => {
+  return (
+    comment.includes('@param') ||
+    comment.includes('@return') ||
+    comment.includes('@deprecated') ||
+    comment.includes('@see')
+  );
+};
+
+const isRegion = (comment: string) => {
+  return comment.startsWith('#region') || comment.startsWith('#endregion');
 };
 
 export default createRule<Options, MessageIds>({
@@ -49,7 +81,18 @@ export default createRule<Options, MessageIds>({
       recommended: 'error',
     },
     fixable: 'code',
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          lineCommentAllowedCapitalisedWords: {
+            type: 'array',
+            uniqueItems: true,
+            description: 'determines which words line comments can start with that have a capital letter',
+          },
+        },
+      },
+    ],
     messages: {
       shouldStartWithSpace: 'A line comment should start with a space',
       shouldStartWithBlock: 'A block comment should start with /**\n *',
@@ -59,8 +102,12 @@ export default createRule<Options, MessageIds>({
       blockCommentEnding: 'A block comment has to end with a dot',
     },
   },
-  defaultOptions: [],
-  create: (context) => {
+  defaultOptions: [
+    {
+      lineCommentAllowedCapitalisedWords: [],
+    },
+  ],
+  create: (context, [{ lineCommentAllowedCapitalisedWords }]) => {
     return {
       Program() {
         const source = context.getSourceCode();
@@ -72,14 +119,18 @@ export default createRule<Options, MessageIds>({
             const secondChar = comment.value[1];
             const lastChar = comment.value[comment.value.length - 1];
 
-            if (comment.value.charCodeAt(0) !== SPACE_CHARCODE) {
+            if (comment.value?.charCodeAt(0) !== SPACE_CHARCODE && !isRegion(comment.value)) {
               context.report({ node: comment, messageId: 'shouldStartWithSpace' });
 
               // if this one fails, the others are interpreted incorrectly
               continue;
             }
 
-            if (isLetter(secondChar) && isCapital(secondChar) && !isWholeFirstWordCapital(comment.value.slice(1))) {
+            if (
+              isLetter(secondChar) &&
+              isCapital(secondChar) &&
+              !isWholeFirstWordCapitalOrAllowed(comment.value.slice(1), lineCommentAllowedCapitalisedWords)
+            ) {
               context.report({ node: comment, messageId: 'lineCommentCapital' });
             }
 
@@ -91,27 +142,76 @@ export default createRule<Options, MessageIds>({
           }
 
           if (comment.type === 'Block') {
-            const [firstChar, secondChar, thirdChar, fourthChar, fifthChar, sixthChar] = comment.value;
-            const lastChar = comment.value[comment.value.length - 3];
-
-            if (
-              firstChar.charCodeAt(0) !== STAR_CHARCODE ||
-              secondChar.charCodeAt(0) !== NEWLINE_CHARCODE ||
-              thirdChar.charCodeAt(0) !== SPACE_CHARCODE ||
-              fourthChar.charCodeAt(0) !== STAR_CHARCODE ||
-              fifthChar.charCodeAt(0) !== SPACE_CHARCODE
-            ) {
-              context.report({ node: comment, messageId: 'shouldStartWithBlock' });
-
-              // if this one fails, the others are interpreted incorrectly
+            if (!comment.value.includes('\n')) {
+              // single line block comments are ignored
               continue;
             }
 
-            if (isLetter(sixthChar) && !isCapital(sixthChar)) {
-              context.report({ node: comment, messageId: 'blockCommentCapital' });
+            const [firstChar] = comment.value;
+            let numberOfSpaces = 0;
+
+            // verify the first char is a '*'
+            if (firstChar.charCodeAt(0) !== STAR_CHARCODE) {
+              context.report({ node: comment, messageId: 'shouldStartWithBlock' });
+
+              continue;
             }
 
-            if (lastChar !== '.') {
+            const commentWithoutFirstStar = comment.value.slice(1);
+
+            for (const char of commentWithoutFirstStar) {
+              if (char.charCodeAt(0) === STAR_CHARCODE) {
+                // should be the newline
+                const firstChar = commentWithoutFirstStar[0];
+
+                // should be the star
+                const secondChar = commentWithoutFirstStar[numberOfSpaces + 1];
+
+                // should be a space
+                const thirdChar = commentWithoutFirstStar[numberOfSpaces + 2];
+
+                // First actual character
+                const fourthChar = commentWithoutFirstStar[numberOfSpaces + 3];
+
+                if (
+                  firstChar?.charCodeAt(0) !== NEWLINE_CHARCODE ||
+                  secondChar?.charCodeAt(0) !== STAR_CHARCODE ||
+                  thirdChar?.charCodeAt(0) !== SPACE_CHARCODE
+                ) {
+                  context.report({ node: comment, messageId: 'shouldStartWithBlock' });
+
+                  // if this one fails, the others are interpreted incorrectly
+                  break;
+                }
+
+                const actualText = commentWithoutFirstStar.slice(numberOfSpaces + 3);
+
+                if (
+                  isLetter(fourthChar) &&
+                  !(
+                    isCapital(fourthChar) ||
+                    isWholeFirstWordCapitalOrAllowed(actualText, lineCommentAllowedCapitalisedWords)
+                  )
+                ) {
+                  context.report({ node: comment, messageId: 'blockCommentCapital' });
+                }
+
+                break;
+              }
+
+              if (![SPACE_CHARCODE, NEWLINE_CHARCODE].includes(char.charCodeAt(0))) {
+                context.report({ node: comment, messageId: 'shouldStartWithBlock' });
+
+                break;
+              } else if (char.charCodeAt(0) === SPACE_CHARCODE) {
+                numberOfSpaces++;
+              }
+            }
+
+            const secondLastChar = comment.value[comment.value.length - 4];
+            const lastChar = comment.value[comment.value.length - 3];
+
+            if (!isJsDoc(comment.value) && isLetter(secondLastChar) && isLetter(lastChar) && lastChar !== '.') {
               context.report({ node: comment, messageId: 'blockCommentEnding' });
             }
 

--- a/src/rules/comment.ts
+++ b/src/rules/comment.ts
@@ -4,7 +4,7 @@ export const ruleName = 'comment-syntax';
 
 type Options = [
   {
-    lineCommentAllowedCapitalisedWords: string[];
+    ignoredWords: string[];
   }
 ];
 
@@ -85,7 +85,7 @@ export default createRule<Options, MessageIds>({
       {
         type: 'object',
         properties: {
-          lineCommentAllowedCapitalisedWords: {
+          ignoredWords: {
             type: 'array',
             uniqueItems: true,
             description: 'determines which words line comments can start with that have a capital letter',
@@ -104,10 +104,10 @@ export default createRule<Options, MessageIds>({
   },
   defaultOptions: [
     {
-      lineCommentAllowedCapitalisedWords: [],
+      ignoredWords: [],
     },
   ],
-  create: (context, [{ lineCommentAllowedCapitalisedWords }]) => {
+  create: (context, [{ ignoredWords }]) => {
     return {
       Program() {
         const source = context.getSourceCode();
@@ -129,7 +129,7 @@ export default createRule<Options, MessageIds>({
             if (
               isLetter(secondChar) &&
               isCapital(secondChar) &&
-              !isWholeFirstWordCapitalOrAllowed(comment.value.slice(1), lineCommentAllowedCapitalisedWords)
+              !isWholeFirstWordCapitalOrAllowed(comment.value.slice(1), ignoredWords)
             ) {
               context.report({ node: comment, messageId: 'lineCommentCapital' });
             }
@@ -188,10 +188,7 @@ export default createRule<Options, MessageIds>({
 
                 if (
                   isLetter(fourthChar) &&
-                  !(
-                    isCapital(fourthChar) ||
-                    isWholeFirstWordCapitalOrAllowed(actualText, lineCommentAllowedCapitalisedWords)
-                  )
+                  !(isCapital(fourthChar) || isWholeFirstWordCapitalOrAllowed(actualText, ignoredWords))
                 ) {
                   context.report({ node: comment, messageId: 'blockCommentCapital' });
                 }

--- a/test/rules/comment.spec.ts
+++ b/test/rules/comment.spec.ts
@@ -100,7 +100,7 @@ ruleTester().run(ruleName, rule, {
           `,
       options: [
         {
-          lineCommentAllowedCapitalisedWords: ['refTableSize'],
+          ignoredWords: ['refTableSize'],
         },
       ],
     },
@@ -110,7 +110,7 @@ ruleTester().run(ruleName, rule, {
         `,
       options: [
         {
-          lineCommentAllowedCapitalisedWords: ['Map'],
+          ignoredWords: ['Map'],
         },
       ],
     },

--- a/test/rules/comment.spec.ts
+++ b/test/rules/comment.spec.ts
@@ -41,6 +41,79 @@ ruleTester().run(ruleName, rule, {
              */
         `
     ),
+    fromFixture(
+      `
+                    /**
+                     * Content the replace the file with.
+                     */
+          `
+    ),
+    fromFixture(
+      stripIndent`
+        /**
+         * Run a script from the \`package.json\`. Optionally you can provide \`env\` variables passed
+         * \`\`\`
+         */
+        `
+    ),
+    fromFixture(
+      stripIndent`
+      /**
+       * @param {number} port
+       * @param {string} coep
+       */
+          `
+    ),
+    fromFixture(
+      stripIndent`
+        new Int32Array(sharedArrayBuffer, 0 /* offset */, 1 /* length */);
+            `
+    ),
+    fromFixture(
+      stripIndent`
+        /* Denotes a text frame */
+        TEXT = 0x1 `
+    ),
+    fromFixture(
+      stripIndent`
+          /**
+           * Foobar
+           * \`export default true\` --► \`const 𝐝𝐞𝐟𝐚𝐮𝐥𝐭 = true\`
+           */
+      `
+    ),
+    fromFixture(
+      stripIndent`
+           //#region
+        `
+    ),
+    fromFixture(
+      stripIndent`
+             //#endregion
+          `
+    ),
+    {
+      code: stripIndent`
+        /**
+         * refTableSize:uint32_t (previously used for sanity checks; safe to ignore)
+         */
+          `,
+      options: [
+        {
+          lineCommentAllowedCapitalisedWords: ['refTableSize'],
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+         // Map<Hostname, IP>
+        `,
+      options: [
+        {
+          lineCommentAllowedCapitalisedWords: ['Map'],
+        },
+      ],
+    },
   ],
   invalid: [
     {

--- a/test/rules/comment.spec.ts
+++ b/test/rules/comment.spec.ts
@@ -12,13 +12,13 @@ ruleTester().run(ruleName, rule, {
     ),
     fromFixture(
       stripIndent`
-          // SHOULD be valid
-        `
+        // SHOULD be valid
+      `
     ),
     fromFixture(
       stripIndent`
-          // \` should be valid
-        `
+        // \` should be valid
+      `
     ),
     fromFixture(
       stripIndent`
@@ -29,24 +29,24 @@ ruleTester().run(ruleName, rule, {
     ),
     fromFixture(
       stripIndent`
-          /**
-           * THIS should start with a capital and end with a dot.
-           */
-        `
+        /**
+         * THIS should start with a capital and end with a dot.
+         */
+      `
     ),
     fromFixture(
       stripIndent`
-            /**
-             * \` should be valid.
-             */
-        `
+        /**
+         * \` should be valid.
+         */
+      `
     ),
     fromFixture(
       `
-                    /**
-                     * Content the replace the file with.
-                     */
-          `
+            /**
+             * Content the replace the file with.
+             */
+      `
     ),
     fromFixture(
       stripIndent`
@@ -54,50 +54,51 @@ ruleTester().run(ruleName, rule, {
          * Run a script from the \`package.json\`. Optionally you can provide \`env\` variables passed
          * \`\`\`
          */
-        `
-    ),
-    fromFixture(
-      stripIndent`
-      /**
-       * @param {number} port
-       * @param {string} coep
-       */
-          `
-    ),
-    fromFixture(
-      stripIndent`
-        new Int32Array(sharedArrayBuffer, 0 /* offset */, 1 /* length */);
-            `
-    ),
-    fromFixture(
-      stripIndent`
-        /* Denotes a text frame */
-        TEXT = 0x1 `
-    ),
-    fromFixture(
-      stripIndent`
-          /**
-           * Foobar
-           * \`export default true\` --► \`const 𝐝𝐞𝐟𝐚𝐮𝐥𝐭 = true\`
-           */
       `
     ),
     fromFixture(
       stripIndent`
-           //#region
-        `
+        /**
+         * @param {number} port
+         * @param {string} coep
+         */
+      `
     ),
     fromFixture(
       stripIndent`
-             //#endregion
-          `
+        new Int32Array(sharedArrayBuffer, 0 /* offset */, 1 /* length */);
+      `
+    ),
+    fromFixture(
+      stripIndent`
+        /* Denotes a text frame */
+        TEXT = 0x1
+      `
+    ),
+    fromFixture(
+      stripIndent`
+        /**
+         * Foobar
+         * \`export default true\` --► \`const 𝐝𝐞𝐟𝐚𝐮𝐥𝐭 = true\`
+         */
+      `
+    ),
+    fromFixture(
+      stripIndent`
+        //#region
+      `
+    ),
+    fromFixture(
+      stripIndent`
+        //#endregion
+      `
     ),
     {
       code: stripIndent`
-        /**
-         * refTableSize:uint32_t (previously used for sanity checks; safe to ignore)
-         */
-          `,
+          /**
+           * refTableSize:uint32_t (previously used for sanity checks; safe to ignore)
+           */
+        `,
       options: [
         {
           ignoredWords: ['refTableSize'],
@@ -118,8 +119,8 @@ ruleTester().run(ruleName, rule, {
   invalid: [
     {
       code: stripIndent`
-            //should throw
-          `,
+              //should throw
+            `,
       errors: [
         {
           messageId: 'shouldStartWithSpace',
@@ -138,8 +139,8 @@ ruleTester().run(ruleName, rule, {
     },
     {
       code: stripIndent`
-          // Should throw
-        `,
+              // Should throw
+            `,
       errors: [
         {
           messageId: 'lineCommentCapital',
@@ -148,8 +149,8 @@ ruleTester().run(ruleName, rule, {
     },
     {
       code: stripIndent`
-            // should throw for the .
-          `,
+              // should throw for the .
+            `,
       errors: [
         {
           messageId: 'lineCommentEnding',
@@ -158,10 +159,10 @@ ruleTester().run(ruleName, rule, {
     },
     {
       code: stripIndent`
-            /**
-             * should throw for the lack of capital.
-             */
-          `,
+              /**
+               * should throw for the lack of capital.
+               */
+            `,
       errors: [
         {
           messageId: 'blockCommentCapital',
@@ -170,10 +171,10 @@ ruleTester().run(ruleName, rule, {
     },
     {
       code: stripIndent`
-              /**
-               * Should throw for the lack of capital
-               */
-          `,
+                /**
+                 * Should throw for the lack of capital
+                 */
+              `,
       errors: [
         {
           messageId: 'blockCommentEnding',


### PR DESCRIPTION
Added support for all use cases in the webcontainer repo.

- option for words to be ignored
- support for jsdoc
- support for `#region` end `#endregion`
- ignores single line block comments so this is allowed `foo(bar /** explainer what this is*/)`
maybe some other stuff.

Also added to the recommended rules.
Actually tested against webcontainer to be sure this time.

