### PR TITLE
chore: add eslint-plugin-jsonc to lint jsonc files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blitz/eslint-plugin",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "An ESLint config to enforce a consistent code styles across StackBlitz projects",
   "keywords": [
     "eslint",
@@ -30,6 +30,7 @@
     "common-tags": "^1.8.0",
     "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-jsonc": "^2.6.0",
     "eslint-plugin-prettier": "^4.0.0"
   },
   "devDependencies": {

--- a/src/configs/recommended.ts
+++ b/src/configs/recommended.ts
@@ -12,6 +12,7 @@ export = {
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:prettier/recommended',
+    'plugin:jsonc/recommended-with-jsonc',
   ],
   plugins: ['@blitz'],
   rules: {

--- a/test/rules/comment.spec.ts
+++ b/test/rules/comment.spec.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'common-tags';
 import { fromFixture } from 'eslint-etc';
-import rule, { defaultOptions, ruleName } from '../../src/rules/comment';
-import { ruleTester } from '../utils';
+import rule, { defaultOptions, ruleName } from '../../src/rules/comment-syntax';
+import { ruleTester, ruleTesterForJSONC } from '../utils';
 
 ruleTester().run(ruleName, rule, {
   valid: [
@@ -214,4 +214,38 @@ ruleTester().run(ruleName, rule, {
     },
   ],
   invalid: [],
+});
+
+
+ruleTesterForJSONC().run(ruleName, rule, {
+  valid: [
+    stripIndent`
+      {
+        // optional property
+        "foo": "bar"
+      }
+    `,
+    stripIndent`
+      {
+        /**
+         * Non ut consequatur sint. Est animi excepturi porro molestiae ut in corrupti.
+         */
+        "lorem": true
+      }
+    `
+  ],
+  invalid: [
+    {
+      code: stripIndent`
+      {
+        // Oopsie I've been a baaad boy.
+        "despicable": 3
+      }
+      `,
+      errors: [
+        'Line comment cannot start with a capital letter unless the entire word is capitalized.',
+        'Line comment cannot end with a dot.'
+      ],
+    },
+  ],
 });

--- a/test/rules/lines-around-comment.spec.ts
+++ b/test/rules/lines-around-comment.spec.ts
@@ -1,6 +1,6 @@
 import { stripIndent } from 'common-tags';
 import rule, { ruleName, defaultOptions } from '../../src/rules/lines-around-comment';
-import { ruleTester } from '../utils';
+import { ruleTester, ruleTesterForJSONC } from '../utils';
 
 ruleTester().run(ruleName, rule, {
   valid: [
@@ -193,4 +193,72 @@ ruleTester().run(ruleName, rule, {
     },
   ],
   invalid: [],
+});
+
+ruleTesterForJSONC().run(ruleName, rule, {
+  valid: [
+    {
+      code: stripIndent`
+        {
+          "version": 0,
+
+          // optional property
+          "foo": "bar"
+        }
+      `,
+      options: [
+        {
+          beforeLineComment: true,
+        },
+      ],
+    },
+    {
+      code: stripIndent`
+        {
+          "ipsum": "wut",
+
+          /**
+           * Non ut consequatur sint. Est animi excepturi porro molestiae ut in corrupti.
+           */
+          "lorem": true
+        }
+      `,
+      options: [
+        {
+          beforeLineComment: true,
+        },
+      ],
+    }
+  ],
+  invalid: [
+    {
+      code: stripIndent`
+        {
+          "a": {
+            "b": "c"
+          },
+          // oh nooo
+          "b": 0
+        }
+      `,
+      output: stripIndent`
+        {
+          "a": {
+            "b": "c"
+          },
+
+          // oh nooo
+          "b": 0
+        }
+      `,
+      options: [
+        {
+          beforeLineComment: true,
+        },
+      ],
+      errors: [
+        'Expected line before comment.'
+      ],
+    },
+  ],
 });

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,4 +1,5 @@
-import { ESLintUtils } from '@typescript-eslint/utils';
+import { RuleTester } from 'eslint';
+import { ESLintUtils, TSESLint } from '@typescript-eslint/utils';
 
 export function ruleTester() {
   return new ESLintUtils.RuleTester({
@@ -8,4 +9,19 @@ export function ruleTester() {
       sourceType: 'module',
     },
   });
+}
+
+export function ruleTesterForJSONC() {
+  return new RuleTester({
+    parser: require.resolve('jsonc-eslint-parser'),
+  }) as unknown as {
+    run<TMessageIds extends string, TOptions extends Readonly<unknown[]>>(
+      name: string,
+      rule: TSESLint.RuleModule<TMessageIds, TOptions>,
+      tests: {
+        valid?: Array<string | RuleTester.ValidTestCase> | undefined;
+        invalid?: RuleTester.InvalidTestCase[] | undefined;
+      }
+    ): void;
+  };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1035,6 +1035,11 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
   integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
+acorn-jsx@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
 acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
@@ -1049,6 +1054,11 @@ acorn@^8.2.4, acorn@^8.7.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
   integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
+acorn@^8.5.0, acorn@^8.8.0:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
+  integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
 
 agent-base@6:
   version "6.0.2"
@@ -1565,6 +1575,15 @@ eslint-etc@^5.1.0:
     tsutils "^3.17.1"
     tsutils-etc "^1.4.1"
 
+eslint-plugin-jsonc@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.6.0.tgz#5a439ec15b4930c022bf157264a3d4f4712b982c"
+  integrity sha512-4bA9YTx58QaWalua1Q1b82zt7eZMB7i+ed8q8cKkbKP75ofOA2SXbtFyCSok7RY6jIXeCqQnKjN9If8zCgv6PA==
+  dependencies:
+    eslint-utils "^3.0.0"
+    jsonc-eslint-parser "^2.0.4"
+    natural-compare "^1.4.0"
+
 eslint-plugin-prettier@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
@@ -1645,6 +1664,15 @@ eslint@^8.11.0:
     strip-json-comments "^3.1.0"
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
+
+espree@^9.0.0:
+  version "9.4.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.4.1.tgz#51d6092615567a2c2cff7833445e37c28c0065bd"
+  integrity sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.3.0"
 
 espree@^9.3.1:
   version "9.3.1"
@@ -2637,6 +2665,16 @@ json5@2.x, json5@^2.1.2:
   integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
   dependencies:
     minimist "^1.2.5"
+
+jsonc-eslint-parser@^2.0.4:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/jsonc-eslint-parser/-/jsonc-eslint-parser-2.1.0.tgz#4c126b530aa583d85308d0b3041ff81ce402bbb2"
+  integrity sha512-qCRJWlbP2v6HbmKW7R3lFbeiVWHo+oMJ0j+MizwvauqnCV/EvtAeEeuCgoc/ErtsuoKgYB8U4Ih8AxJbXoE6/g==
+  dependencies:
+    acorn "^8.5.0"
+    eslint-visitor-keys "^3.0.0"
+    espree "^9.0.0"
+    semver "^7.3.5"
 
 kleur@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
This PR adds `eslint-plugin-jsonc` to make it possible to lint `json(c)` files as well with the same rules.

A few notes regarding linting `*.json(c)` files:
  - You'll probably want to update your `.eslintignore` file to ignore generated json files.
  - `eslint-plugin-jsonc` generate different node types for a couple of item (see full list there: https://github.com/ota-meshi/jsonc-eslint-parser/blob/master/src/parser/ast.ts#L33) but the root node still has the `Program` type which is why our lints still works :tada:
  - If you want to disable a specifc rule you can add this to `overrides` in `.eslintrc`:
```jsonc
{
    "files": ["*.json"],
    "rules": { /* ... */ }
}
```
